### PR TITLE
fix: add missing key for block_form in dynamics.yaml

### DIFF
--- a/quiqr/model/includes/dynamics.yaml
+++ b/quiqr/model/includes/dynamics.yaml
@@ -80,7 +80,8 @@
   _mergePartial: block_contact_someone
   content_type: block_contact_someone
 
-- content_type: block_form
+- key: dynbxform
+  content_type: block_form
   _mergePartial: block_form
 
 ########
@@ -93,4 +94,3 @@
 
 - key: dynffhidden
   _mergePartial: dynformfield_hidden
-


### PR DESCRIPTION
Fixes the import of this community template in Quiqr.
Quiqrs Zod validation throws errors for missing keys, causing a white screen when opening this project.